### PR TITLE
Bump runtime-version to 40

### DIFF
--- a/com.system76.Popsicle.yaml
+++ b/com.system76.Popsicle.yaml
@@ -1,6 +1,6 @@
 app-id: com.system76.Popsicle
 runtime: org.freedesktop.Platform
-runtime-version: '19.08'
+runtime-version: '40'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
 - org.freedesktop.Sdk.Extension.rust-stable


### PR DESCRIPTION
org.freedesktop.Platform//19.08 is too old and is not used by new software. That means we need to download that version of the SDK just for popsicle